### PR TITLE
Updated gem to be compatible with rails <= 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+# For ruby-version
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,15 @@
 source 'http://rubygems.org'
 
-gem 'activerecord', '>= 3.2', '< 4'
+gem 'activerecord', '>= 3.2', '< 4.2'
 gem 'multi_json'
+
+# v11 has a removed method that rspec-core < 3.4.4 uses.
+# See: https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11
+gem 'rake', '< 11.0'
 
 group :development, :test do
   gem 'rspec', '~> 2.0'
-  gem 'pg'
+  gem 'pg', '~> 0.20.0'
 end
 
 group :development do

--- a/activerecord-postgres-json.gemspec
+++ b/activerecord-postgres-json.gemspec
@@ -5,15 +5,15 @@
 # stub: activerecord-postgres-json 0.2.1 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "activerecord-postgres-json"
+  s.name = "activerecord-postgres-json".freeze
   s.version = "0.2.1"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Roman Shterenzon"]
-  s.date = "2015-01-16"
-  s.description = "Active Record support for PostgreSQL JSON type"
-  s.email = "romanbsd@yahoo.com"
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Roman Shterenzon".freeze]
+  s.date = "2019-02-07"
+  s.description = "Active Record support for PostgreSQL JSON type".freeze
+  s.email = "romanbsd@yahoo.com".freeze
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md"
@@ -37,42 +37,45 @@ Gem::Specification.new do |s|
     "spec/spec_helper.rb",
     "spec/support/database_setup.rb"
   ]
-  s.homepage = "http://github.com/romanbsd/activerecord-postgres-json"
-  s.licenses = ["MIT"]
-  s.rubygems_version = "2.4.3"
-  s.summary = "Active Record support for PostgreSQL JSON type"
+  s.homepage = "http://github.com/romanbsd/activerecord-postgres-json".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "Active Record support for PostgreSQL JSON type".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activerecord>, ["< 4", ">= 3.2"])
-      s.add_runtime_dependency(%q<multi_json>, [">= 0"])
-      s.add_development_dependency(%q<rspec>, ["~> 2.0"])
-      s.add_development_dependency(%q<pg>, [">= 0"])
-      s.add_development_dependency(%q<rubocop>, [">= 0"])
-      s.add_development_dependency(%q<rdoc>, [">= 0"])
-      s.add_development_dependency(%q<bundler>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
+      s.add_runtime_dependency(%q<activerecord>.freeze, ["< 4.2", ">= 3.2"])
+      s.add_runtime_dependency(%q<multi_json>.freeze, [">= 0"])
+      s.add_runtime_dependency(%q<rake>.freeze, ["< 11.0"])
+      s.add_development_dependency(%q<rspec>.freeze, ["~> 2.0"])
+      s.add_development_dependency(%q<pg>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rubocop>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rdoc>.freeze, [">= 0"])
+      s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<activerecord>, ["< 4", ">= 3.2"])
-      s.add_dependency(%q<multi_json>, [">= 0"])
-      s.add_dependency(%q<rspec>, ["~> 2.0"])
-      s.add_dependency(%q<pg>, [">= 0"])
-      s.add_dependency(%q<rubocop>, [">= 0"])
-      s.add_dependency(%q<rdoc>, [">= 0"])
-      s.add_dependency(%q<bundler>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
+      s.add_dependency(%q<activerecord>.freeze, ["< 4.2", ">= 3.2"])
+      s.add_dependency(%q<multi_json>.freeze, [">= 0"])
+      s.add_dependency(%q<rake>.freeze, ["< 11.0"])
+      s.add_dependency(%q<rspec>.freeze, ["~> 2.0"])
+      s.add_dependency(%q<pg>.freeze, [">= 0"])
+      s.add_dependency(%q<rubocop>.freeze, [">= 0"])
+      s.add_dependency(%q<rdoc>.freeze, [">= 0"])
+      s.add_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<activerecord>, ["< 4", ">= 3.2"])
-    s.add_dependency(%q<multi_json>, [">= 0"])
-    s.add_dependency(%q<rspec>, ["~> 2.0"])
-    s.add_dependency(%q<pg>, [">= 0"])
-    s.add_dependency(%q<rubocop>, [">= 0"])
-    s.add_dependency(%q<rdoc>, [">= 0"])
-    s.add_dependency(%q<bundler>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
+    s.add_dependency(%q<activerecord>.freeze, ["< 4.2", ">= 3.2"])
+    s.add_dependency(%q<multi_json>.freeze, [">= 0"])
+    s.add_dependency(%q<rake>.freeze, ["< 11.0"])
+    s.add_dependency(%q<rspec>.freeze, ["~> 2.0"])
+    s.add_dependency(%q<pg>.freeze, [">= 0"])
+    s.add_dependency(%q<rubocop>.freeze, [">= 0"])
+    s.add_dependency(%q<rdoc>.freeze, [">= 0"])
+    s.add_dependency(%q<bundler>.freeze, [">= 0"])
+    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
   end
 end
 

--- a/lib/activerecord-postgres-json/activerecord.rb
+++ b/lib/activerecord-postgres-json/activerecord.rb
@@ -6,6 +6,14 @@ module ActiveRecord
     PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:json]  = { name: 'json' }
     PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:jsonb] = { name: 'jsonb' }
 
+    if ::ActiveRecord.version >= Gem::Version.new("4.0.0")
+      # As suggested here: http://www.innovationontherun.com/fixing-unknown-oid-geography-errors-with-postgis-and-rails-4-0/
+      # to prevent the Rails 4.0/4.1 error of
+      # "unknown OID: {field}"
+      PostgreSQLAdapter::OID.register_type('json', PostgreSQLAdapter::OID::Identity.new)
+      PostgreSQLAdapter::OID.register_type('jsonb', PostgreSQLAdapter::OID::Identity.new)
+    end
+
     class PostgreSQLColumn < Column
       # Adds the json type for the column.
       def simplified_type_with_json(field_type)

--- a/spec/activerecord-postgres-json_spec.rb
+++ b/spec/activerecord-postgres-json_spec.rb
@@ -31,7 +31,7 @@ describe 'ActiverecordPostgresJson', db: true do
         data ->> 'title'            AS title,
         data #>> '{author,name}'    AS author_name,
         data #>> '{author,email}'   AS author_email,
-        (data ->> 'tags')::json     AS tags,
+        (data ->> 'tags')::jsonb     AS tags,
         (data ->> 'draft')::boolean AS draft
       FROM posts
     SQL

--- a/spec/support/database_setup.rb
+++ b/spec/support/database_setup.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'pg'
+require 'yaml'
 
 db_config = YAML.load_file(File.expand_path('../../database.yml', __FILE__))
 


### PR DESCRIPTION
Rails 4.2 introduces native support for json types, but if you're upgrading a legacy app to 4.0 or 4.1, you might need this in the interim.

Greatly appreciate the patch @nzifnab authored. Opening this PR against original upstream so his work can be more easily found by others who might need it.

Renamed the repo in our fork to be able to publish to rubygems without name conflicts, since we can't specify a github source with a branch name in gemspec files.

If you need to install the rails4-friendly version before this PR gets accepted, see https://rubygems.org/gems/activerecord-postgres-json-rails4
